### PR TITLE
upgrade to diagrams-1.3

### DIFF
--- a/diagrams-qrcode.cabal
+++ b/diagrams-qrcode.cabal
@@ -37,10 +37,10 @@ library
   exposed-modules:
     Diagrams.QRCode
   build-depends:
-      base          >= 4.5 && < 4.8
+      base          >= 4.5 && < 4.9
     , array
     , colour
-    , diagrams-core == 1.2.*
-    , diagrams-lib  == 1.2.*
+    , diagrams-core == 1.3.*
+    , diagrams-lib  == 1.3.*
   hs-source-dirs: src/
   ghc-options: -Wall

--- a/examples/using-haskell-qrencode.hs
+++ b/examples/using-haskell-qrencode.hs
@@ -1,4 +1,5 @@
-import Text.Blaze.Svg.Renderer.Utf8 (renderSvg)   -- blaze-svg
+{-# LANGUAGE OverloadedStrings #-}
+import Lucid.Svg (renderBS)                       -- lucid-svg
 import qualified Data.ByteString.Lazy.Char8 as L8 -- bytestring
 import qualified Data.QRCode as QR                -- haskell-qrencode
 import qualified Diagrams.Backend.SVG as D        -- diagrams-svg
@@ -17,4 +18,4 @@ main = do
   let dia = D.scale 6 $ QR.stroke $ QR.pathMatrix $ QR.toMatrix qrcode
 
   -- Render diagram
-  L8.putStrLn $ renderSvg $ D.renderDia D.SVG (D.SVGOptions D.Absolute Nothing) dia
+  L8.putStrLn $ renderBS $ D.renderDia D.SVG (D.SVGOptions (D.mkWidth 250) Nothing "") dia

--- a/examples/using-qrcode.hs
+++ b/examples/using-qrcode.hs
@@ -1,4 +1,5 @@
-import Text.Blaze.Svg.Renderer.Utf8 (renderSvg)   -- blaze-svg
+{-# LANGUAGE OverloadedStrings #-}
+import Lucid.Svg (renderBS)                       -- lucid-svg
 import qualified Codec.Binary.QRCode as QR        -- qrcode
 import qualified Data.ByteString.Lazy.Char8 as L8 -- bytestring
 import qualified Diagrams.Backend.SVG as D        -- diagrams-svg
@@ -18,4 +19,4 @@ main = do
   let dia = D.scale 6 $ QR.stroke $ QR.pathArray $ fmap not $ QR.toArray qrcode
 
   -- Render diagram
-  L8.putStrLn $ renderSvg $ D.renderDia D.SVG (D.SVGOptions D.Absolute Nothing) dia
+  L8.putStrLn $ renderBS $ D.renderDia D.SVG (D.SVGOptions (D.mkWidth 250) Nothing "") dia

--- a/src/Diagrams/QRCode.hs
+++ b/src/Diagrams/QRCode.hs
@@ -4,7 +4,8 @@ module Diagrams.QRCode (pathList, pathMatrix, pathArray, stroke) where
 import Control.Arrow ((***))
 import Data.Array (assocs, Array, Ix)
 import Data.Colour.Names (black, white)
-import Data.Monoid (mempty)
+import Data.Monoid (Any, mempty)
+import qualified Diagrams.Attributes as D
 import qualified Diagrams.Core as D
 import qualified Diagrams.Located as D
 import qualified Diagrams.Path as D
@@ -14,7 +15,9 @@ import qualified Diagrams.TwoD as D
 
 -- | Stroke using default QR code colors (black on white) and
 -- with the \"quiet\" region.
-stroke :: (D.Backend b D.R2, D.Renderable (D.Path D.R2) b) => D.Path D.R2 -> D.Diagram b D.R2
+stroke :: (D.Backend b D.V2 Double, D.Renderable (D.Path D.V2 Double) b)
+          => D.Path D.V2 Double
+          -> D.QDiagram b D.V2 Double Any
 stroke = D.bg white . quiet . D.fc black . D.lw D.none . D.stroke
   where
     zoneX = D.strutX 4
@@ -30,14 +33,14 @@ stroke = D.bg white . quiet . D.fc black . D.lw D.none . D.stroke
 -- | Convert a QR code represented as a list of bounded values
 -- into a 'Path'.  'minBound' values are considered to be
 -- \"off\", while every other value is considered to be \"on\".
-pathList :: (Bounded a, Eq a, Integral ix) => [((ix, ix), a)] -> D.Path D.R2
+pathList :: (Bounded a, Eq a, Integral ix) => [((ix, ix), a)] -> D.Path D.V2 Double
 pathList = D.Path . fmap (uncurry (flip D.at) . (p2int *** toTrail))
   where p2int = D.p2 . (fromIntegral *** fromIntegral)
 
 
 -- | Same as 'pathList', but from a matrix represented as a list
 -- of lists.
-pathMatrix :: (Bounded a, Eq a) => [[a]] -> D.Path D.R2
+pathMatrix :: (Bounded a, Eq a) => [[a]] -> D.Path D.V2 Double
 pathMatrix matrix =
   pathList $ do
     (r, row) <- count matrix
@@ -47,10 +50,10 @@ pathMatrix matrix =
 
 
 -- | Same as 'pathList', but from an array.
-pathArray :: (Bounded a, Eq a, Integral ix, Ix ix) => Array (ix, ix) a -> D.Path D.R2
+pathArray :: (Bounded a, Eq a, Integral ix, Ix ix) => Array (ix, ix) a -> D.Path D.V2 Double
 pathArray = pathList . assocs
 
 
 -- | Convert a value into a 'Trail'.
-toTrail :: (Bounded a, Eq a) => a -> D.Trail D.R2
+toTrail :: (Bounded a, Eq a) => a -> D.Trail D.V2 Double
 toTrail x = if x == minBound then mempty else D.square 1


### PR DESCRIPTION
I've updated the code and examples to work with diagrams 1.3 as per their [migration guide](https://wiki.haskell.org/Diagrams/Dev/Migrate1.3).

I was able to get the `using-haskell-qrencode.hs` example working, but I couldn't get `using-qrcode.hs` to work from `stdin`, but it was fine with:

``` hs
let input = "TEXT"
```

instead of:

``` hs
input <- getContents
```
